### PR TITLE
WebView: Disable explicit content scaling in macOS

### DIFF
--- a/WebView.cpp
+++ b/WebView.cpp
@@ -79,7 +79,11 @@ WebView::WebView()
     // FIXME: Allow passing these values as arguments
     m_page_client->set_viewport_rect({ 0, 0, 800, 600 });
 
+#ifdef AK_OS_MACOS
+    m_inverse_pixel_scaling_ratio = 1.0;
+#else
     m_inverse_pixel_scaling_ratio = 1.0 / devicePixelRatio();
+#endif
 
     verticalScrollBar()->setSingleStep(24);
     horizontalScrollBar()->setSingleStep(24);


### PR DESCRIPTION
Currently, every website is wrongly scaled in macOS using a high dpi screen.
Before:
<img width="1470" alt="Screenshot 2022-09-23 at 19 50 20" src="https://user-images.githubusercontent.com/4399446/192028934-c808d4b0-7940-42c1-936e-c2830714cee0.png">

After:
<img width="1470" alt="Screenshot 2022-09-23 at 19 52 14" src="https://user-images.githubusercontent.com/4399446/192028974-6771750b-02e5-4238-88c0-e068edcc5e6d.png">
