### PR TITLE
Allow clicking middle mouse button to open URL in a new tab

### DIFF
--- a/BrowserWindow.cpp
+++ b/BrowserWindow.cpp
@@ -283,6 +283,12 @@ BrowserWindow::BrowserWindow(int webdriver_fd_passing_socket)
     setCentralWidget(m_tabs_container);
 }
 
+void BrowserWindow::create_tab_with_url(AK::String const& url) {
+    new_tab();
+    auto& tab = m_tabs.last();
+    tab.navigate(qstring_from_akstring(url));
+}
+
 void BrowserWindow::debug_request(String const& request, String const& argument)
 {
     if (!m_current_tab)

--- a/BrowserWindow.h
+++ b/BrowserWindow.h
@@ -28,6 +28,8 @@ public:
 
     int tab_index(Tab*);
 
+    void create_tab_with_url(AK::String const& url);
+
 public slots:
     void tab_title_changed(int index, QString const&);
     void tab_favicon_changed(int index, QIcon icon);

--- a/Tab.cpp
+++ b/Tab.cpp
@@ -28,7 +28,7 @@ Tab::Tab(BrowserWindow* window, int webdriver_fd_passing_socket)
     m_layout->setSpacing(0);
     m_layout->setContentsMargins(0, 0, 0, 0);
 
-    m_view = new WebContentView(webdriver_fd_passing_socket);
+    m_view = new WebContentView(window, webdriver_fd_passing_socket);
     m_toolbar = new QToolBar(this);
     m_location_edit = new QLineEdit(this);
 

--- a/WebContentView.cpp
+++ b/WebContentView.cpp
@@ -6,6 +6,7 @@
 
 #define AK_DONT_REPLACE_STD
 
+#include "BrowserWindow.h"
 #include "WebContentView.h"
 #include "ConsoleWidget.h"
 #include "ModelTranslator.h"
@@ -55,8 +56,9 @@
 #include <QTreeView>
 #include <QVBoxLayout>
 
-WebContentView::WebContentView(int webdriver_fd_passing_socket)
-    : m_webdriver_fd_passing_socket(webdriver_fd_passing_socket)
+WebContentView::WebContentView(BrowserWindow* browser_window, int webdriver_fd_passing_socket)
+    : m_browser_window(browser_window)
+    , m_webdriver_fd_passing_socket(webdriver_fd_passing_socket)
 {
     setMouseTracking(true);
 
@@ -797,9 +799,10 @@ void WebContentView::notify_server_did_click_link(Badge<WebContentClient>, AK::U
 
 void WebContentView::notify_server_did_middle_click_link(Badge<WebContentClient>, AK::URL const& url, String const& target, unsigned int modifiers)
 {
-    (void)url;
     (void)target;
     (void)modifiers;
+
+    m_browser_window->create_tab_with_url(url.serialize());
 }
 
 void WebContentView::notify_server_did_start_loading(Badge<WebContentClient>, AK::URL const& url, bool is_redirect)

--- a/WebContentView.h
+++ b/WebContentView.h
@@ -42,13 +42,14 @@ enum class ColorScheme {
 };
 
 class Tab;
+class BrowserWindow;
 
 class WebContentView final
     : public QAbstractScrollArea
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
-    explicit WebContentView(int webdriver_fd_passing_socket);
+    explicit WebContentView(BrowserWindow* browser_window, int webdriver_fd_passing_socket);
     virtual ~WebContentView() override;
 
     void load(AK::URL const&);
@@ -219,5 +220,6 @@ private:
 
     RefPtr<Gfx::Bitmap> m_backup_bitmap;
 
+    BrowserWindow* m_browser_window { nullptr };
     int m_webdriver_fd_passing_socket { -1 };
 };


### PR DESCRIPTION
This PR adds a new method to BrowserWindow to create a new tab with a target URL and calls it on middle mouse click.